### PR TITLE
Update tough-cookie version due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "request-promise-core": "1.1.1",
     "stealthy-require": "^1.1.0",
-    "tough-cookie": ">=2.3.0"
+    "tough-cookie": ">=2.3.3"
   },
   "peerDependencies": {
     "request": "^2.34"


### PR DESCRIPTION
There has been a new release of tough-cookie to fix the following:

```
The tough-cookie module is vulnerable to regular expression denial of service. Input of around 50k characters is required for a slow down of around 2 seconds.

Unless node was compiled using the -DHTTP_MAX_HEADER_SIZE= option the default header max length is 80kb so the impact of the ReDoS is limited to around 7.3 seconds of blocking.

At the time of writing all version <=2.3.2 are vulnerable
```
See: https://nodesecurity.io/advisories/525
