### PR TITLE
Don't clear entire require cache to force request module reload

### DIFF
--- a/lib/rp.js
+++ b/lib/rp.js
@@ -4,7 +4,7 @@ var configure = require('request-promise-core/configure/request2');
 
 // delete the request module from the require cache so that
 // users can require an unaltered request instance!
-/* global Module */
+var Module = require('module');
 var filename = Module._resolveFilename('request', module);
 delete require.cache[filename];
 var request = require('request');

--- a/lib/rp.js
+++ b/lib/rp.js
@@ -1,16 +1,13 @@
 'use strict';
 
-var configure = require('request-promise-core/configure/request2'),
-    stealthyRequire = require('stealthy-require');
+var configure = require('request-promise-core/configure/request2');
 
-// Load Request freshly - so that users can require an unaltered request instance!
-var request = stealthyRequire(require.cache, function () {
-    return require('request');
-},
-function () {
-    require('tough-cookie');
-}, module);
-
+// delete the request module from the require cache so that
+// users can require an unaltered request instance!
+/* global Module */
+var filename = Module._resolveFilename('request', module);
+delete require.cache[filename];
+var request = require('request');
 
 configure({
     request: request,


### PR DESCRIPTION
`stealthyRequire` clears the entire require cache which causes problems when a module in the dependency tree executes code or maintains state.

The specific instance that I'm working with is the `appoptics-apm` performance monitoring code but this has the potential to impact other packages as well.

I replaced `stealthyRequire` with code that removes the `request` module from the require cache. 

I went through all the `./lib/*` dependencies and didn't see anything that was executed nor any state maintained in those modules. It doesn't look like it is necessary to invalidate them.

This should speed up the loading time by not invalidating the cache but I haven't tested that. It does work correctly (as far as I can tell) in the application I'm working with.