### PR TITLE
fix: target tough-cookie 2.x to preserve Node 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "request-promise-core": "1.1.1",
     "stealthy-require": "^1.1.0",
-    "tough-cookie": ">=2.3.3"
+    "tough-cookie": "^2.3.3"
   },
   "peerDependencies": {
     "request": "^2.34"


### PR DESCRIPTION
Tough-cookie now ends up resolving to 3.0.0 (published today) which drops support for Node 6.

Also fairly confident that CI is failing for other reasons.