### PR TITLE
fix: target tough-cookie 2.x to preserve node 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "dependencies": {
     "request-promise-core": "1.1.1",
-    "stealthy-require": "^1.1.0",
-    "tough-cookie": ">=2.3.3"
+    "stealthy-require": "^1.1.1",
+    "tough-cookie": "^2.5.0"
   },
   "peerDependencies": {
-    "request": "^2.34"
+    "request": "^2.88.0"
   },
   "devDependencies": {
     "body-parser": "~1.15.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tough-cookie": "^2.5.0"
   },
   "peerDependencies": {
-    "request": "^2.88.0"
+    "request": "^2.34"
   },
   "devDependencies": {
     "body-parser": "~1.15.2",

--- a/test/spec/request-test.js
+++ b/test/spec/request-test.js
@@ -146,7 +146,7 @@ describe('Request-Promise-Native', function () {
         var cookiejar = rp.jar();
 
         expect(function () {
-            cookiejar.setCookie(sessionCookie, 'https://api.mydomain.com');
+            cookiejar.setCookie(sessionCookie.toString(), 'https://api.mydomain.com');
         }).to.not.throw();
 
     });


### PR DESCRIPTION
Tough-cookie now ends up resolving to 3.0.0 (published today) which drops support for Node 6.

Node 0.12.0 and iojs builds are failing but not because of this PR.