### PR TITLE
docs: deprecated as well as request

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 [![Dependency Status](https://img.shields.io/david/request/request-promise-native.svg?style=flat-square&maxAge=2592000)](https://david-dm.org/request/request-promise-native)
 [![Known Vulnerabilities](https://snyk.io/test/npm/request-promise-native/badge.svg?style=flat-square&maxAge=2592000)](https://snyk.io/test/npm/request-promise-native)
 
+# Deprecated!
+
+As of Feb 11th 2020, [`request`](https://github.com/request/request) is fully deprecated. No new changes are expected to land. In fact, none have landed for some time.  
+This package is also deprecated because it depends on `request`.
+
+---
+
 This package is similar to [`request-promise`](https://www.npmjs.com/package/request-promise) but uses native ES6+ promises.
 
 Please refer to the [`request-promise` documentation](https://www.npmjs.com/package/request-promise). Everything applies to `request-promise-native` except the following:


### PR DESCRIPTION
This package will be deprecated as well as request. Thanks a lot for your great work.

resolve #57